### PR TITLE
Set Java version to 17 and add SLF4J API dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,13 +13,23 @@
     <url>https://github.com/alhamidawi/mdc-utils</url>
 
     <properties>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <slf4j-api.version>2.0.16</slf4j-api.version>
         <spotless-maven-plugin.version>2.43.0</spotless-maven-plugin.version>
         <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
         <findsecbugs-plugin.version>1.13.0</findsecbugs-plugin.version>
         <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j-api.version}</version>
+        </dependency>
+    </dependencies>
 
 
     <build>


### PR DESCRIPTION
Updated the Maven project to use Java 17 by adding the java.version property. Introduced SLF4J API as a new dependency with version 2.0.16 to support logging improvements. These changes ensure compatibility with modern Java features and enhance logging capabilities.